### PR TITLE
fix: update apt preferences.d to not break system packages

### DIFF
--- a/files/apt/preferences
+++ b/files/apt/preferences
@@ -1,0 +1,38 @@
+# never prefer repository
+Package: *
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 1
+
+# prefer packages
+
+Package: podman
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: podman-aardvark-dns
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: podman-docker
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: podman-gvproxy
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: podman-netavark
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: containernetworking-dnsname
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: containernetworking-plugins
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500
+
+Package: containernetworking-podman-machine
+Pin: origin downloadcontent.opensuse.org
+Pin-Priority: 500

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -23,6 +23,17 @@
   loop:
     - { dest: /etc/apt/keyrings }
     - { dest: /usr/share/keyrings }
+    - { dest: /etc/apt/preferences.d }
+
+- name: prepare files
+  ansible.builtin.file:
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner | default('root') }}"
+    group: "{{ item.group | default('root') }}"
+    mode: "{{ item.mode | default('0644') }}"
+    path: "{{ item.path | default(None) }}"
+  loop:
+    - { dest: /etc/apt/preferences.d/99-alvistack, path: apt/preferences }
 
 - name: apt-key add
   vars:


### PR DESCRIPTION
Add a preferences for `apt-cache` to not break any system packages on Debian-based systems.

This merge requests creates a pin for the `alvistack` repositories on Debian-based systems so that any `python3-*` based package that is more recent in the `alvistack` repository will not take predecense over the system packages, which easily breaks a Debian based system.

Requesting for comments whether this would be an acceptable merge request for you or not.